### PR TITLE
Correct getSimplexSize + format + typo

### DIFF
--- a/include/MinA/algorithm/Simplex.h
+++ b/include/MinA/algorithm/Simplex.h
@@ -52,7 +52,6 @@ class Simplex : public OptimizationAlgorithm {
     double difference;
     int stoppingIteration;
     string FunctionName;
-
 };
 
 #endif

--- a/include/MinA/algorithm/SimplexParallel.h
+++ b/include/MinA/algorithm/SimplexParallel.h
@@ -12,7 +12,6 @@
 #include <boost/archive/text_iarchive.hpp>
 #include "MinA/algorithm/Simplex.h"
 
-
 typedef std::pair<std::map<std::string, double>, double> vertex;
 typedef std::vector<std::pair<std::map<std::string, double>, double>> vertexVector;
 
@@ -24,7 +23,6 @@ class SimplexParallel : public Simplex {
     void sendVertex(vertex& A, int receiver, int tag);
     vertex receiveVertex(int sender, int tag);
     void calculateAc(vertex& Ac, vertex& M, vertex& Ajp);
-
 };
 
 #endif

--- a/include/MinA/common/FunctionToBeOptimized.h
+++ b/include/MinA/common/FunctionToBeOptimized.h
@@ -20,10 +20,12 @@ class FunctionToBeOptimized {
     FunctionToBeOptimized() : handle(MinA_ETHROW)
     {
     }
+
     void setHandle(handle_arith ha)
     {
         handle = ha;
     }
+
     double evaluate(std::map<std::string, double> para)
     {
         double result;
@@ -33,7 +35,7 @@ class FunctionToBeOptimized {
                 throw Arithmetical_Exception(result);
         }
         catch (Arithmetical_Exception& ae) {
-          std::stringstream err;
+            std::stringstream err;
             switch (handle) {
                 case MinA_EHIGH:
                     err << "Exception caught:" << ae.what()
@@ -54,13 +56,15 @@ class FunctionToBeOptimized {
         }
         return result;
     }
+    
     virtual double getEvaluation(std::map<std::string, double> para) = 0;
+
     int getParameterSize()
     {
         return parameters.size();
     }
-    std::set<Parameter> parameters;
 
+    std::set<Parameter> parameters;
 };
 
 #endif

--- a/include/MinA/common/Minimizer.h
+++ b/include/MinA/common/Minimizer.h
@@ -14,5 +14,4 @@ class Minimizer {
                     std::shared_ptr<OptimizationAlgorithm> sim);
     Result operator()(std::shared_ptr<FunctionToBeOptimized> start,
                       std::shared_ptr<OptimizationAlgorithm> sim);
-
 };

--- a/test/sanityTest/TestFunction.cpp
+++ b/test/sanityTest/TestFunction.cpp
@@ -16,7 +16,7 @@ class SquareFunction : public FunctionToBeOptimized {
             Parameter par;
             par.setName("x" + to_string(i));
             par.setStartingPoint(8);
-	    par.setBoundaryLeft(-10);
+            par.setBoundaryLeft(-10);
             par.setBoundaryRight(10);
             parameters.insert(par);
         }
@@ -101,14 +101,14 @@ class Matthias_function : public FunctionToBeOptimized {
   public:
     Matthias_function(int dimension)
     {
-        alpha = 6;
-        beta = 3;
-        gramma = 1;
-        eata = 1;
+        double alpha = 6;
+        double beta = 3;
+        double gamma = 1;
+        double eta = 1;
         for (int i = 0; i < dimension; i++) {
             Parameter par;
             par.setName("x" + to_string(i));
-            par.setStartingPoint(i*0.5);
+            par.setStartingPoint(i * 0.5);
             par.setBoundaryLeft(-5);
             par.setBoundaryRight(5);
             parameters.insert(par);
@@ -120,10 +120,9 @@ class Matthias_function : public FunctionToBeOptimized {
         double sum_xs = 0;
         for (auto it : parameters)
             sum_xs += pow(para[it.getName()], 2);
-        double fz = alpha * pow(sin(beta * sum_xs), 2) +  sum_xs*gramma * exp(eata * sum_xs);
+        double fz = alpha * pow(sin(beta * sum_xs), 2) + sum_xs * gamma * exp(eta * sum_xs);
         return fz;
     }
-    double alpha, beta, gramma, eata;
 };
 
 class McCormick_function : public FunctionToBeOptimized {
@@ -197,24 +196,26 @@ class Gaussian_function : public FunctionToBeOptimized {
     {
         double sum_xsin = 0;
         for (auto it : parameters)
-            sum_xsin += pow((para[it.getName()]+1),2);
+            sum_xsin += pow((para[it.getName()] + 1), 2);
         double fz = -exp(-sum_xsin);
         return fz;
     }
     double d;
 };
+
 class Modify_Matthias_function : public FunctionToBeOptimized {
   public:
     Modify_Matthias_function(int dimension)
     {
-        alpha = 6;
-        beta = 3;
-        gramma = 1;
-        eata = 1;
+        double alpha = 6;
+        double beta = 3;
+        double gamma = 1;
+        double eta = 1;
+
         for (int i = 0; i < dimension; i++) {
             Parameter par;
             par.setName("x" + to_string(i));
-            par.setStartingPoint(i*0.5);
+            par.setStartingPoint(i * 0.5);
             par.setBoundaryLeft(-5);
             par.setBoundaryRight(5);
             parameters.insert(par);
@@ -226,9 +227,8 @@ class Modify_Matthias_function : public FunctionToBeOptimized {
         double sum_xs = 0;
         for (auto it : parameters)
             sum_xs += pow(para[it.getName()], 2);
-        double fz = alpha * pow(cos(beta * sum_xs), 2) +  gramma * exp(eata * sum_xs);
+        double fz = alpha * pow(cos(beta * sum_xs), 2) + gamma * exp(eta * sum_xs);
         return fz;
     }
-    double alpha, beta, gramma, eata;
 };
 #endif


### PR DESCRIPTION
getSimplexSize was wrong and more expensive than necessary (sqrt(pow(x,2))=abs(x)). The last vertex was not included in the loop.
Concerning the format, we should use clang-format before every commit, or the history gets really messy.

Cheers,
    Raffaele
